### PR TITLE
implement context menu item to start a timed action for butchering

### DIFF
--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/TimedActions/ButcherCorpseTimedAction.lua
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/TimedActions/ButcherCorpseTimedAction.lua
@@ -1,0 +1,91 @@
+require "TimedActions/ISBaseTimedAction"
+
+ButcherCorpseAction = ISBaseTimedAction:derive("ButcherCorpseAction");
+ButcherCorpseAction.soundDelay = 1
+
+function ButcherCorpseAction:isValid()
+    if self.corpseBody:getStaticMovingObjectIndex() < 0 then
+        return false
+    end
+    return true
+end
+
+function ButcherCorpseAction:waitToStart()
+    self.character:faceThisObject(self.corpseBody)
+    return self.character:shouldBeTurning()
+end
+
+function ButcherCorpseAction:update()
+    if self.soundTime + ButcherCorpseAction.soundDelay < getTimestamp() then
+        self.soundTime = getTimestamp()
+        self.sound = self.character:getEmitter():playSound("SliceMeat")
+        addSound(self.character, self.character:getX(), self.character:getY(), self.character:getZ(), 10, 10)
+    end
+
+    self.corpse:setJobDelta(self:getJobDelta());
+    self.character:faceThisObject(self.corpseBody);
+
+    self.character:setMetabolicTarget(Metabolics.LightWork);
+end
+
+function ButcherCorpseAction:start()
+    self.corpse:setJobType(getText("ContextMenu_Recipe_ButCor_Butcher_Corpse"));
+    self.corpse:setJobDelta(0.0);
+    self:setActionAnim("Loot");
+    self.character:SetVariable("LootPosition", "Low");
+
+    self.character:reportEvent("EventLootItem");
+end
+
+function ButcherCorpseAction:stop()
+    if self.sound and self.sound ~= 0 and self.character:getEmitter():isPlaying(self.sound) then
+        self.character:getEmitter():stopSound(self.sound);
+    end
+
+    ISBaseTimedAction.stop(self);
+    self.corpse:setJobDelta(0.0);
+end
+
+function ButcherCorpseAction:perform()
+    --forceDropHeavyItems(self.character)
+    self.corpse:setJobDelta(0.0);
+    self.character:getInventory():setDrawDirty(true);
+    
+    local recipe = getScriptManager():getRecipe("ButCor.ButCor Butcher Corpse")
+    local result = recipe:getResult()
+
+    for i=1, result:getCount() do
+      self.character:getInventory():AddItem(result:getFullType());
+    end
+
+    self.corpseBody:getSquare():removeCorpse(self.corpseBody, false);
+
+    local pdata = getPlayerData(self.character:getPlayerNum());
+    if pdata ~= nil then
+        pdata.playerInventory:refreshBackpacks();
+        pdata.lootInventory:refreshBackpacks();
+    end
+
+    -- needed to remove from queue / start next.
+    ISBaseTimedAction.perform(self);
+end
+
+function ButcherCorpseAction:new(character, corpse, butcherItem, time)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o.character = character;
+    o.corpse = corpse:getItem();
+    o.corpseBody = corpse;
+    o.butcherItem = butcherItem;
+    o.stopOnWalk = true;
+    o.stopOnRun = true;
+    o.maxTime = time;
+    o.forceProgressBar = true;
+    o.soundTime = 0
+
+    --if character:isTimedActionInstant() then
+    --    o.maxTime = 1;
+    --end
+    return o
+end

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/UI/ButcherCorpseContextMenu.lua
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/UI/ButcherCorpseContextMenu.lua
@@ -1,0 +1,68 @@
+ButcherCorpses = {};
+
+ButcherCorpses.Recipe = getScriptManager():getRecipe("ButCor.ButCor Butcher Corpse")
+
+local function getRecipeTools()
+    for _,source in ipairs(ButcherCorpses.Recipe:getSource()) do
+		if source:isKeep() then
+			return source:getItems()
+		end
+	end
+	return {"Machete", "MeatCleaver", "HandAxe", "Axe", "WoodAxe", "HuntingKnife"}
+end
+
+local function hasRequiredWeapon(player)
+    local inventory = getSpecificPlayer(player):getInventory()
+    for _, weapon in ipairs(getRecipeTools()) do
+        if inventory:contains(weapon) then
+            return true
+        end
+    end
+    return false
+end
+
+local function isButcherItem(item)
+    for _, weapon in ipairs(getRecipeTools()) do
+        if not item:isBroken() and item:getType() == weapon then
+			return true
+		end
+    end
+	return false
+end
+
+ButcherCorpses.getButcherItem = function(player)
+	local playerInv = player:getInventory();
+	-- first check if we have a valid tool equipped
+	local handItem = player:getPrimaryHandItem()
+	if handItem and isButcherItem(handItem) then
+		return handItem
+	end
+	-- if not, check if there's a valid tool in inventory
+	return playerInv:getFirstEvalRecurse(isButcherItem)
+end
+
+local oldCreateMenu = ISWorldObjectContextMenu.createMenu
+ISWorldObjectContextMenu.createMenu = function(player, worldobjects, x, y, test)
+    -- call the original createMenu function
+    local context = oldCreateMenu(player, worldobjects, x, y, test)
+
+	-- add butcher option requirements met
+	if hasRequiredWeapon(player) then
+    	local body = IsoObjectPicker.Instance:PickCorpse(x, y)
+    	if body then
+			context:addOption(getText("ContextMenu_ButCor_Butcher_Corpse"), worldobjects, ButcherCorpses.onButcherCorpse, body, player);
+    	end
+	end
+	return context
+end
+
+ButcherCorpses.onButcherCorpse = function(worldobjects, WItem, player)
+	local playerObj = getSpecificPlayer(player)
+	-- walk to corpse
+	if WItem:getSquare() and luautils.walkAdj(playerObj, WItem:getSquare()) then
+		-- equip item and start action
+		local butcherItem = ISWorldObjectContextMenu.equip(playerObj, playerObj:getPrimaryHandItem(), ButcherCorpses.getButcherItem(playerObj), true);
+		ISTimedActionQueue.add(ButcherCorpseAction:new(playerObj, WItem,butcherItem, ButcherCorpses.Recipe:getTimeToMake()));
+	end
+end
+

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/ContextMenu_EN.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/ContextMenu_EN.txt
@@ -1,0 +1,5 @@
+ContextMenu_EN = {
+
+	ContextMenu_ButCor_Butcher_Corpse = "Butcher Corpse for Flesh",
+	
+}

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/Recipes_EN.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/Recipes_EN.txt
@@ -1,0 +1,5 @@
+Recipes_EN = {
+
+    Recipe_ButCor_Butcher_Corpse = "Butcher Corpse for Flesh",
+
+}

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Butcher.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Butcher.txt
@@ -5,7 +5,7 @@ module ButCor {
   } 
 
 
-  recipe Butcher Corpse {
+  recipe ButCor Butcher Corpse {
     keep Machete/MeatCleaver/HandAxe/Axe/WoodAxe/HuntingKnife,
     CorpseMale/CorpseFemale,
     Result:Fleshofcorpse=3,


### PR DESCRIPTION
If player has all tools to do the butcher recipe, they see a new context menu option (right click) on a corpse. The action will make the character move towards the corpse, equip the tool, play an animation and sound, remove the corpse and spawns the result of the recipe inside the players equipment.

Furthermore, recipe and context action are now called "Butcher Corpse for Flesh" to avoid confusion with other mods that add similar functionality. This request came from a workshop comment.