### PR TITLE
Balance flesh weight

### DIFF
--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Butcher.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Butcher.txt
@@ -8,7 +8,7 @@ module ButCor {
   recipe ButCor Butcher Corpse {
     keep Machete/MeatCleaver/HandAxe/Axe/WoodAxe/HuntingKnife,
     CorpseMale/CorpseFemale,
-    Result:Fleshofcorpse=3,
+    Result:Fleshofcorpse=4,
     Time:240.0,
     OnCreate:onCreate_getFreshResult,
     Category:General,

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Corpse.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/scripts/Corpse.txt
@@ -4,7 +4,7 @@ module ButCor {
   item Fleshofcorpse {
     Type=Food,
     FoodType=Meat,
-    Weight=0.15,
+    Weight=3,
     DisplayName=Corpse Flesh,
     Icon=CorpseFlesh,
 	DangerousUncooked = TRUE,
@@ -27,7 +27,7 @@ module ButCor {
   item CookedCorpseFlesh {
     Type=Food,
     FoodType=Meat,
-    Weight=0.15,
+    Weight=3,
     DisplayName=Corpse Flesh,
     Icon=CorpseFlesh,
 	DangerousUncooked = TRUE,


### PR DESCRIPTION
Corpses are 20 weight units heavy. Moving them is a hell of a inventory struggle and I feel this mod should still include part of that struggle. Currently the crafted flesh weighs near to nothing, so I increased the weight to 3 while making the recipe create 4 units resulting in a weight of 12. This is way easier to handle, while still maintaining part of the struggle.

Ideally this should be configurable, but I am not sure how to do this on recipes.