### PR TITLE
Add SandboxVar to spawn butchered meat via context menu on the ground

### DIFF
--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/TimedActions/ButcherCorpseTimedAction.lua
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/client/TimedActions/ButcherCorpseTimedAction.lua
@@ -51,15 +51,19 @@ function ButcherCorpseAction:perform()
     self.corpse:setJobDelta(0.0);
     self.character:getInventory():setDrawDirty(true);
     
-    local recipe = getScriptManager():getRecipe("ButCor.ButCor Butcher Corpse")
-    local result = recipe:getResult()
+    local result = ButcherCorpses.Recipe:getResult();
+    local corpseSquare = self.corpseBody:getSquare();
 
     for i=1, result:getCount() do
-      self.character:getInventory():AddItem(result:getFullType());
+        if SandboxVars.ButCor.DropMeatOnGround then
+            corpseSquare:AddWorldInventoryItem(result:getFullType(), 0, 0, 0)
+        else
+            self.character:getInventory():AddItem(result:getFullType());
+        end
     end
-
-    self.corpseBody:getSquare():removeCorpse(self.corpseBody, false);
-
+    
+    corpseSquare:removeCorpse(self.corpseBody, false);
+    
     local pdata = getPlayerData(self.character:getPlayerNum());
     if pdata ~= nil then
         pdata.playerInventory:refreshBackpacks();

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -15,5 +15,8 @@ Sandbox_EN = {
 	Sandbox_ButCorEffectOnEatCooked_option2 = "Food Sickness"
 	Sandbox_ButCorEffectOnEatCooked_option3 = "Zombie Infection"
 	Sandbox_ButCorEffectOnEatCooked_option4 = "Zombie Infection + Food Sickness"
+
+	Sandbox_ButCorDropMeatOnGround = "Butchering action drops meat on ground",
+	Sandbox_ButCorDropMeatOnGround_tooltip = "If enabled, butchering corpses via the right click menu will spawn Corpse Flesh on the ground instead of in the inventory."
 	
 }

--- a/Butcher Corpses/Contents/mods/Butcher Corpses/media/sandbox-options.txt
+++ b/Butcher Corpses/Contents/mods/Butcher Corpses/media/sandbox-options.txt
@@ -11,3 +11,9 @@ option ButCor.EffectOnEatCooked
 	type = enum, numValues = 4, default = 1, 
 	page = ButCor, translation = ButCorEffectOnEatCooked,
 }
+
+option ButCor.DropMeatOnGround
+{
+	type = boolean, default = false, 
+	page = ButCor, translation = ButCorDropMeatOnGround,
+}


### PR DESCRIPTION
Adds sandbox var to configure if meat butchered from corpses via the context menu should spawn on the ground instead of in the inventory.

Based on branch feature/sickness